### PR TITLE
Clarify license

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ see examples at [examples](./examples).
 ## License
 
 Have fun.
+
+(The official license is MIT)


### PR DESCRIPTION
This PR clarifies the license as MIT (according to `setup.py`)